### PR TITLE
Buffer cleaning

### DIFF
--- a/R200/R200.cpp
+++ b/R200/R200.cpp
@@ -235,8 +235,12 @@ bool R200::receiveData(unsigned long timeOut){
     while (_serial->available()) {
       uint8_t b = _serial->read();
       if(bytesReceived > RX_BUFFER_LENGTH - 1) {
+        // Buffer overflow - flush everything and start over
         Serial.print("Error: Max Buffer Length Exceeded!");
         flush();
+        bytesReceived = 0;
+        // Clear buffer again
+        for (int i = 0; i < RX_BUFFER_LENGTH; i++) { _buffer[i] = 0; }
         return false;
       }
       else {
@@ -251,6 +255,13 @@ bool R200::receiveData(unsigned long timeOut){
   } else {
       return false;
   }
+
+  // Timeout reached without valid frame
+  if (bytesReceived > 0) {
+    // Flush remaining data in serial buffer
+    flush();
+  }
+
   return false;
 }
 

--- a/R200/R200.h
+++ b/R200/R200.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <Arduino.h>
 
-#define RX_BUFFER_LENGTH 64
+#define RX_BUFFER_LENGTH 256
 
 class R200 {
 


### PR DESCRIPTION
When using multiple polling mode, reading several tags in quick succession often caused buffer overflows.

### Fix

- Increased RX_BUFFER_LENGTH from 64 → 256.
- Added safe handling for overflows and timeouts:
  - Flush and reset buffer on overflow.
  - Clear remaining data on timeout.

### Result

Prevents frequent buffer overflows and improves stability when reading multiple tags.